### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mattobee/mocom11ty/security/code-scanning/3](https://github.com/mattobee/mocom11ty/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily reads repository contents and does not perform write operations, the permissions can be restricted to `contents: read`. This ensures the workflow has the minimal access required to complete its tasks.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to the specific job (`test`) if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
